### PR TITLE
Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -2,17 +2,24 @@ APP_NAME=IMDBClone
 APP_ENV=local
 APP_KEY=base64:brgho/TFMFiDEfvqbVCHp94AhazJ9FkVnAD0DpmHqWE=
 APP_DEBUG=true
-APP_URL=http://imdb-clone.test
+APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
 
-DB_CONNECTION=pgsql
-DB_HOST=ec2-52-70-135-246.compute-1.amazonaws.com
-DB_PORT=5432
-DB_DATABASE=d1u3a2skqa2rpi
-DB_USERNAME=yqtndwnsgwdmct
-DB_PASSWORD=d330e79856b7d24173ae34fa7b05d7bbeffb5d929ef6e0d40924200ba6aed91b
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=clone
+DB_USERNAME=root
+DB_PASSWORD=root
+
+# DB_CONNECTION=pgsql
+# DB_HOST=ec2-52-70-135-246.compute-1.amazonaws.com
+# DB_PORT=5432
+# DB_DATABASE=d1u3a2skqa2rpi
+# DB_USERNAME=yqtndwnsgwdmct
+# DB_PASSWORD=d330e79856b7d24173ae34fa7b05d7bbeffb5d929ef6e0d40924200ba6aed91b
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
     # DATABASE
     db:
-        image: mysql:5.7
+        image: mariadb:latest
         container_name: imdbclone-db
         restart: unless-stopped
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,94 +1,66 @@
-# For more information: https://laravel.com/docs/sail
-version: '3'
+# Run in shell
+# 1. docker-compose build app
+# 2. docker-compose up -d
+# 3. docker-compose exec app composer i && npm i
+
+version: '3.8'
+
 services:
-    laravel.test:
+    # APP
+    app:
         build:
-            context: ./vendor/laravel/sail/runtimes/8.0
-            dockerfile: Dockerfile
             args:
-                WWWGROUP: '${WWWGROUP}'
-        image: sail-8.0/app
-        ports:
-            - '${APP_PORT:-80}:80'
-        environment:
-            WWWUSER: '${WWWUSER}'
-            LARAVEL_SAIL: 1
+                user: user
+                uid: 1000
+            context: ./docker-compose/
+        image: imdbclone
+        container_name: imdbclone-app
+        restart: unless-stopped
+        working_dir: /var/www/
         volumes:
-            - '.:/var/www/html'
-        networks:
-            - sail
+            - ./:/var/www
+
+    # DATABASE
+    db:
+        image: mysql:5.7
+        container_name: imdbclone-db
+        restart: unless-stopped
+        environment:
+            MYSQL_DATABASE: ${DB_DATABASE}
+            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+            MYSQL_PASSWORD: ${DB_PASSWORD}
+            MYSQL_USER: ${DB_USERNAME}
+        volumes:
+            - clonedb:/var/lib/mysql
+
+    # WEB SERVER
+    nginx:
+        image: nginx:alpine
+        container_name: imdbclone-nginx
+        restart: unless-stopped
+        ports:
+            - 80:80
+        volumes:
+            - ./:/var/www
+            - ./docker-compose/nginx:/etc/nginx/conf.d/
+    #PMA
+    phpmyadmin:
         depends_on:
-            - mysql
-            # - pgsql
-            - redis
-            # - selenium
-    # selenium:
-    #     image: 'selenium/standalone-chrome'
-    #     volumes:
-    #         - '/dev/shm:/dev/shm'
-    #     networks:
-    #         - sail
-    mysql:
-        image: 'mysql:8.0'
+            - db
+        links:
+            - db
+        image: phpmyadmin:latest
+        restart: always
         ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
+            - '8081:80'
         environment:
+            PMA_HOST: db
+            MYSQL_USERNAME: '${DB_USERNAME}'
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         volumes:
-            - 'sailmysql:/var/lib/mysql'
-        networks:
-            - sail
-        healthcheck:
-          test: ["CMD", "mysqladmin", "ping"]
-#    pgsql:
-#        image: postgres:13
-#        ports:
-#            - '${FORWARD_DB_PORT:-5432}:5432'
-#        environment:
-#            PGPASSWORD: '${DB_PASSWORD:-secret}'
-#            POSTGRES_DB: '${DB_DATABASE}'
-#            POSTGRES_USER: '${DB_USERNAME}'
-#            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
-#        volumes:
-#            - 'sailpostgresql:/var/lib/postgresql/data'
-#        networks:
-#            - sail
-#        healthcheck:
-#          test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
-    redis:
-        image: 'redis:alpine'
-        ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
-        volumes:
-            - 'sailredis:/data'
-        networks:
-            - sail
-        healthcheck:
-          test: ["CMD", "redis-cli", "ping"]
-    # memcached:
-    #     image: 'memcached:alpine'
-    #     ports:
-    #         - '11211:11211'
-    #     networks:
-    #         - sail
-    mailhog:
-        image: 'mailhog/mailhog:latest'
-        ports:
-            - '${FORWARD_MAILHOG_PORT:-1025}:1025'
-            - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
-        networks:
-            - sail
-networks:
-    sail:
-        driver: bridge
+            - pma:/sessions
+        container_name: phpmyadmin
+
 volumes:
-    sailmysql:
-        driver: local
-#    sailpostgresql:
-#        driver: local
-    sailredis:
-        driver: local
+    clonedb:
+    pma:

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:7.4-fpm
+
+# Arguments defined in docker-compose.yml
+ARG user
+ARG uid
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    unzip \
+    build-essential \
+    openssl \
+    libssl-dev
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Get latest NODEJS & NPM
+COPY --from=node:latest . .
+
+# Create system user to run Composer and Artisan Commands
+RUN useradd -G www-data,root -u $uid -d /home/$user $user
+RUN mkdir -p /home/$user/.composer && \
+    chown -R $user:$user /home/$user
+
+# Set working directory
+WORKDIR /var/www
+
+USER $user

--- a/docker-compose/nginx/travellist.conf
+++ b/docker-compose/nginx/travellist.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/public;
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}


### PR DESCRIPTION
This PR aims to simplify local development with docker containers.

- install [docker desktop](https://www.docker.com/products/docker-desktop). While docker compose should install with docker desktop, compose is crucial for this to work, so make sure you have it installed before you continue (`docker-compose -v`). If you don't have it read the [Docker Compose install page](https://docs.docker.com/compose/install/).
- do `git pull`, switch to docker branch `git checkout docker`, then run `docker-compose build app && docker-compose up -d && docker-compose exec app composer i && npm i` in project root folder shell.
**NOTE!** The first time you run this it will take som time (all containers have to download and install). Subsequent runs will normally only take 1-2 seconds.

Once everything is done you can view the app on [http://localhost](http://localhost). If you need to work with the database you can either view it thru [phpmyadmin](http://localhost:8081) or by going to the MySQL container in the CLI via docker.

To run `artisan` or `composer` commands on the server you can either click the "CLI" button (>_ in a circle) on `imdbclone-app` which will open a new shell terminal inside that container or you can run `docker exec -it [CONTAINER_ID] /bin/sh; exit` where **[CONTAINER_ID]** is the ID of image `imdbclone` from running `docker ps` in shell.

The persistent database is in `clonedb`. If for whatever reason you want to trash it, do the following in shell:
- `docker-compose down` to stop containers
- `docker volume ls` to list current volumes, make sure `clonedb` is there
- `docker volume rm clonedb` to delete clonedb persistant data

To delete all volumes:
- `docker-compose down` to stop containers
- `docker rm -f $(docker ps -a -q)` to delete all containers
- `docker volume rm $(docker volume ls -q)` to delete all volumes