### PR TITLE
fix: reverted to {id} from {movie} in review post route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -61,4 +61,4 @@ Route::delete('account/{movie}', [AddedMovieController::class, 'destroy'])->name
 Route::get('movie/{id}/review-write', [MovieReviewWriteController::class, 'index'])->name('page_movie_review_create');
 
 // create
-Route::post('movie/{movie}/review-write', [MovieReviewWriteController::class, 'create']);
+Route::post('movie/{id}/review-write', [MovieReviewWriteController::class, 'create']);


### PR DESCRIPTION
Someone hade change the review post rout to include `{movie}` rather than `{id}`. This caused null value when posting a review.

Reverted back to `{id}`.