### PR TITLE
MySQL <-> PgSQL case handling

### DIFF
--- a/app/Http/Controllers/ComponentSearchController.php
+++ b/app/Http/Controllers/ComponentSearchController.php
@@ -11,9 +11,19 @@ class ComponentSearchController extends Controller
     {
         // Take input data ($request->input) and search database table movies
         $search = $request->input;
-        $results = DB::table('movies')
-            ->where('title', 'LIKE', "%$search%")
-            ->get();
+        $results = '';
+
+        // MySql handles case sensitive from lower case string with LIKE
+        if (env('DB_CONNECTION') !== 'pgsql') {
+            $results = DB::table('movies')
+                ->where('title', 'LIKE', "%$search%")
+                ->get();
+        } else {
+            // PgSql needs ILIKE to match case insensitive
+            $results = DB::table('movies')
+                ->where('title', 'ILIKE', "%$search%")
+                ->get();
+        }
 
         return $results;
 


### PR DESCRIPTION
Trying to fix the final piece of the search case sensitive problem. PgSQL needs `ILIKE` for same matching as MySQL `LIKE` to handle case sensitive strings.